### PR TITLE
Move cache section - change to correct disk

### DIFF
--- a/content/linux/install-guides/manjaro-btrfs.md
+++ b/content/linux/install-guides/manjaro-btrfs.md
@@ -220,7 +220,7 @@ cd /run/timeshift/backup/@/var/cache
 ls | xargs sudo mv -t /run/timeshift/backup/@cache/
 
 
-export CRYPTUUID=$(blkid -s UUID -o value /dev/vda2)
+export CRYPTUUID=$(blkid -s UUID -o value /dev/mapper/crypt_vda3)
 echo "UUID=${CRYPTUUID}    /var/cache    btrfs    rw,noatime,compress=zstd:3,ssd,space_cache,commit=120,subvol=@cache 0 0" >> /etc/fstab
 sudo mount -av
 ```


### PR DESCRIPTION
First of all thank you for that great tutorial, it really helped me to set up manjaro with the architect. 
Just one little correction: In section where you describe how to move /var/cache to the correct subvolume you try to get the UUID from the wrong disk. It should be the luks disk and not the hardware disk. 