### PR TITLE
Update pop-os-btrfs-20-04.md

### DIFF
--- a/content/linux/install-guides/pop-os-btrfs-20-04.md
+++ b/content/linux/install-guides/pop-os-btrfs-20-04.md
@@ -198,10 +198,15 @@ ls /mnt/
 # @
 cd /
 ```
-Now let's create two more subvolumes `@home` and `@swap`. Note that the Pop!_OS installer does neither create a user nor a swapfile, so there is nothing we need to copy over.
+Now let's create two more subvolumes `@home` and `@swap`. Note that the Pop!_OS installer does not create a swapfile, so there is nothing we need to copy over for swap.
 ```bash
 btrfs subvolume create /mnt/@home
 # Create subvolume '/mnt/@home'
+mv /mnt/@/home/* /mnt/@home/
+ls -a /mnt/@/home
+# . ..
+ls -a /mnt/@home
+# . .. wmutschl
 btrfs subvolume create /mnt/@swap
 # Create subvolume '/mnt/@swap'
 btrfs subvolume list /mnt


### PR DESCRIPTION
Current Pop!_OS 20.04 LTS installer now creates a user and associated home directory that needs to be copied. Found this today while installing. Sneaky, because you can get through the process without errors and login. Then, as you would expect, things get weird. Took a few minutes and a couple reboots to figure out what was going on. Also, thanks for your work on these guides. It is much appreciated. Take care